### PR TITLE
accept strings as in py2

### DIFF
--- a/nose_json/plugin.py
+++ b/nose_json/plugin.py
@@ -85,7 +85,10 @@ class JsonReportPlugin(Plugin):
         else:
             type = 'error'
             self.stats['errors'] += 1
-        tb = ''.join(traceback.format_exception(*err))
+        if issubclass(type(err), Exception):
+            tb = ''.join(traceback.format_exception(*err))
+        else:
+            tb = err
         id = test.id()
         self.results.append({
             'classname': ':'.join(id_split(id)[0].rsplit('.', 1)),

--- a/nose_json/plugin.py
+++ b/nose_json/plugin.py
@@ -102,7 +102,10 @@ class JsonReportPlugin(Plugin):
 
     def addFailure(self, test, err, capt=None, tb_info=None):
         taken = self._get_time_taken()
-        tb = ''.join(traceback.format_exception(*err))
+        if issubclass(type(err), Exception):
+            tb = ''.join(traceback.format_exception(*err))
+        else:
+            tb = err
         self.stats['failures'] += 1
         id = test.id()
         self.results.append({


### PR DESCRIPTION
hi @dcramer , you probably forgot about this bit a long time ago, but in case you still use it as well.
I ran into a problem porting some code topython3 and this hack is how I worked around it. The RC is probably in another plugin but I haven't that yet. If you recognise the issue of an exception passed as a string, please let me know.